### PR TITLE
Change bootstrap success variable

### DIFF
--- a/app/assets/stylesheets/ecosystems.scss
+++ b/app/assets/stylesheets/ecosystems.scss
@@ -23,7 +23,7 @@ $color-grey-dark: #4C4C61;
 /* Tokens to override bootstrap colours */
 $primary: $color-purple;
 $secondary: $color-grey;
-$success: $color-green;
+$success: $color-green-dark;
 $info: $color-purple-light;
 $warning: $color-orange-light;
 $danger: $color-orange-dark;


### PR DESCRIPTION
Small fix to the green colour used for bootstrap's 'success' colour, as it was very hard to read in badges


Before
![image](https://github.com/user-attachments/assets/d38d36be-577d-4092-a44b-fd4117d79250)

After
![image](https://github.com/user-attachments/assets/a15b8191-6824-436c-82ce-a13d8a440e67)

