### PR TITLE
A couple of bug fixes from latest funds work

### DIFF
--- a/app/assets/stylesheets/ecosystems.scss
+++ b/app/assets/stylesheets/ecosystems.scss
@@ -346,12 +346,11 @@ body {
   li {
     padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
   }
-}
-
-.nav {
-  @include media-breakpoint-up(lg) {
-    justify-content: end;
-  }
+	.nav {
+		@include media-breakpoint-up(lg) {
+			justify-content: end;
+		}
+	}
 }
 
 .dark-section {
@@ -513,7 +512,7 @@ body {
 
 .purple-grad-bg  {
   background-color: $color-purple-dark;
-  background: linear-gradient(0deg, $color-purple-dark 50%, $color-purple 100%);
+  background: linear-gradient(0deg, $color-purple-dark 0%, $color-purple 50%);
   color: $color-white;
 }
 


### PR DESCRIPTION
- .nav was too low specificity, meaning we could use .nav anywhere else, but it's needed for multiple bootstrap components
- .purple-grad-bg had an error in its definition