### PR TITLE
A new header and navigation for ecosystems home

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,7 +92,7 @@
   height: 150px;
   width: 150px;
   right: 10%;
-  top: -50px;
+  top: -30px;
 
   @include media-breakpoint-up(md) {
     height: 220px;

--- a/app/assets/stylesheets/ecosystems.scss
+++ b/app/assets/stylesheets/ecosystems.scss
@@ -486,6 +486,9 @@ body {
 .header__local {
   border-top: 1px solid $color-grey;
   margin-top: 2rem;
+  hr {
+    margin: 0.5rem 0;
+  }
 }
 
 .header__local__sitename {
@@ -526,7 +529,7 @@ body {
   }
 
   .dropdown {
-    padding-top:4px;
+    padding-top: 4px;
   }
 
   .dropdown:last-of-type {
@@ -539,20 +542,67 @@ body {
   [aria-expanded="true"] & {
     border-color: $color-green;
   }
-
   &:hover,
   &:focus {
     border-color: $color-green;
   }
 }
 
-.table a:not(.btn, .help-link) {
-  @include spesh-link();
+
+/* New navigation */
+.header__local__primary-navigation {
+  font-weight: bold;
+  // make it line up with the left side
+  margin-left: -1rem;
 }
 
-/*  Header */
-.header {
-  padding: 2em 0 0;
+.header__local__secondary-navigation {
+  font-size: 0.875em;
+  margin-left: -1rem;
+  @include media-breakpoint-up(lg) {
+    // make it line up with the right side
+    margin-right: -1rem;
+    margin-left: 0;
+  }
+}
+
+//replaces .header__local__navigation
+.header__local__login-navigation {
+  @include media-breakpoint-up(lg) {
+    margin-left: 0;
+  }
+
+  .nav-link {
+    padding: 0;
+    font-size: 0.875em;
+  }
+
+  .nav-item {
+    padding: 0;
+  }
+
+  .nav {
+    @include media-breakpoint-up(lg) {
+      justify-content: end;
+    }
+  }
+
+  .dropdown {
+    padding-top: 0;
+  }
+
+  .dropdown:last-of-type {
+    padding-right: 0;
+  }
+}
+
+.header__local__login-navigation .dropdown:last-of-type {
+  padding-left: 0;
+}
+
+
+.table a:not(.btn, .help-link) {
+  @include spesh-link();
 }
 
 /*  Footer */

--- a/app/views/accounts/_header.html.erb
+++ b/app/views/accounts/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="breadcrumb-section py-3  mt-3">
+<div class="breadcrumb-section py-3 mt-2">
   <div class="container">
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">

--- a/app/views/checkout/new.html.erb
+++ b/app/views/checkout/new.html.erb
@@ -1,4 +1,4 @@
-<div class="breadcrumb-section py-3 mt-3">
+<div class="breadcrumb-section py-3 mt-2">
   <div class="container">
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">

--- a/app/views/pages/pricing.html.erb
+++ b/app/views/pages/pricing.html.erb
@@ -1,4 +1,4 @@
-<div class="breadcrumb-section py-3 mt-3">
+<div class="breadcrumb-section py-3 mt-2">
   <div class="container">
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,14 +1,14 @@
 <header class="header">
   <div class="header__global">
     <div class="container">
-      <div class="row mb-4">
+      <div class="row align-items-center my-3">
         <div class="col-md-6 header__global__site-logo-wrapper mb-3 mb-lg-0">
           <h1>
             <a class="site-logo" href="/">ecosyste.ms</a>
           </h1>
         </div>
         <div class="col-md-6 text-md-end">
-			<a class="header__global__menu-link" role="button" aria-expanded="false" aria-controls="header__global__menu" data-bs-toggle="collapse" href="#header__global__menu">All services <%= bootstrap_icon 'caret-down-fill', width: 12, height: 12 %></a>
+			    <a class="header__global__menu-link d-inline-flex align-items-center" role="button" aria-expanded="false" aria-controls="header__global__menu" data-bs-toggle="collapse" href="#header__global__menu">All services <%= bootstrap_icon 'caret-down-fill', width: 12, height: 12 %></a>
         </div>
       </div>
       
@@ -29,9 +29,9 @@
     </div>
   </div>
 
-  <div class="header__local pt-3">
+  <div class="header__local pt-2">
     <div class="container">
-      <div class="row">
+      <div class="row flex align-items-center">
         <div class="col-lg-3 col-md-4">
           <h1 class="h3 header__local__sitename">
             <a class="header__local__homelink" href="/">
@@ -39,14 +39,33 @@
             </a>
           </h1>
         </div>
-        <div class="col-lg-5 col-md-8">
-          <p class="header__local__description">
+        <div class="col-lg-5 col-md-7">
+          <p class="header__local__description mb-0">
             <%= app_description %>
           </p>
         </div>
-        <div class="col-lg-4 col-md-12">
-          <%= render 'shared/menu' %>
+        <div class="col-12 col-lg-4 col-md-1 d-flex justify-content-between justify-content-md-end my-3 my-md-0">
+         <button class="btn btn-secondary btn-sm d-flex align-items-center gap-2 d-md-none" type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#headerLocalNav"
+            aria-controls="headerLocalNav"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+            id="headerLocalNavToggler"
+          >
+          <%= bootstrap_icon "list", id: "headerLocalNavIcon", aria_hidden: true, width: 20, height: 20 %>
+                Menu
+          </button>
+          <%= render 'shared/menu_login' %>
         </div>
+      </div>
+      <hr aria-hidden="true" class="d-none d-md-block" role="presentation">
+      <div
+        id="headerLocalNav"
+        class="collapse d-lg-flex align-items-lg-center justify-content-lg-between"
+      >
+        <%= render 'shared/menu' %>
+        <%= render 'shared/menu_secondary' %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_menu.html.erb
+++ b/app/views/shared/_menu.html.erb
@@ -1,16 +1,17 @@
-<nav class="header__local__navigation">
-  <ul class="nav">
+<nav class="header__local__primary-navigation">
+  <ul class="nav flex-column flex-lg-row align-items-start align-items-lg-center mb-0">
+    <li class="nav-item">
+      <a class="nav-link" href="https://docs.ecosyste.ms">Documentation</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="/commercial">Commercial</a>
+    </li>
     <li class="nav-item">
       <a class="nav-link" href="/api">API</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" href="https://opencollective.com/ecosystems" target="_blank">Support</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="https://github.com/ecosyste-ms/" target="_blank">GitHub</a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link" href="mailto:hello@ecosyste.ms">Contact</a>
+      <a class="nav-link" href="https://blog.ecosyste.ms/update/2022/06/01/ecosytems-identify-secure-and-sustain.html">About</a>
     </li>
   </ul>
-</nav>
+  
+</nav><hr class="d-lg-none my-3">

--- a/app/views/shared/_menu_login.html.erb
+++ b/app/views/shared/_menu_login.html.erb
@@ -1,0 +1,23 @@
+<nav class="header__local__login-navigation">
+  <ul class="nav">
+    <% if logged_in? %>
+    <li class="nav-item">
+      <div class="dropdown nav-item user-menu" id="user-menu">
+        <a class="" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <img src="<%= current_account.profile_picture_url %>" alt="User menu" height="36" width="36" class="rounded-circle user-menu__image" />
+        </a>
+
+        <ul class="dropdown-menu" aria-labelledby="user-menu" role="menu">
+          <li><p class="dropdown-header"><%= current_account.name %></p></li>
+          <li><a class="dropdown-item" href="/account">Account</a></li>
+          <li><a class="dropdown-item" href="/logout">Logout</a></li>
+        </ul>
+      </div>
+    </li>
+    <% else %>
+    <li class="nav-item">  
+      <a class="nav-link small" href="/login">Login</a>
+    </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/shared/_menu_secondary.html.erb
+++ b/app/views/shared/_menu_secondary.html.erb
@@ -1,0 +1,13 @@
+<nav class="header__local__secondary-navigation ms-lg-auto">
+  <ul class="nav flex-column flex-lg-row align-items-start align-items-lg-center mb-0">
+    <li class="nav-item">
+      <a class="nav-link" href="https://opencollective.com/ecosystems" target="_blank">Sponsor</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="https://github.com/ecosyste-ms/" target="_blank">Contribute</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" href="mailto:hello@ecosyste.ms">Contact</a>
+    </li>
+  </ul>
+</nav>


### PR DESCRIPTION
now involves
- Primary navigation (specific to this app)
- Secondary navigation (the same across every app, but in context - eg github goes to the right repo)
- Log in menu (for apps that have log in)
- mobile menu for small screens

<img width="1364" height="298" alt="image" src="https://github.com/user-attachments/assets/6b525369-a872-438f-8cf3-72e1968c4d6a" />
<img width="348" height="662" alt="image" src="https://github.com/user-attachments/assets/fc60d8b6-734b-4ef0-bde5-ba6a11aa9529" />

Should fix #715 too