### PR TITLE
Fix Stripe Clover invoice handling

### DIFF
--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -41,12 +41,8 @@ module Webhooks
           handle_subscription_updated(event.data.object)
         when 'customer.subscription.deleted'
           handle_subscription_deleted(event.data.object)
-        when 'invoice.payment_succeeded'
-          handle_invoice_payment_succeeded(event.data.object)
-        when 'invoice.payment_failed'
-          handle_invoice_payment_failed(event.data.object)
-        when 'invoice.finalized'
-          handle_invoice_finalized(event.data.object)
+        when 'invoice.payment_succeeded', 'invoice.payment_failed', 'invoice.finalized'
+          handle_invoice(event.data.object)
         else
           Rails.logger.info "[Stripe Webhook] Unhandled event type: #{event.type}"
         end
@@ -57,13 +53,12 @@ module Webhooks
         stripe_event.mark_as_failed!(e)
         Rails.logger.error "[Stripe Webhook] Failed to process event #{event.id}: #{e.class} - #{e.message}"
         Rails.logger.error e.backtrace.first(5).join("\n")
-        # Still return 200 so Stripe doesn't retry
+        render json: { error: 'Webhook processing failed' }, status: :internal_server_error
+        return
       end
 
       render json: { received: true }, status: :ok
     end
-
-    private
 
     def handle_subscription_created(stripe_subscription)
       stripe_subscription = fetch_object_if_needed(stripe_subscription, Stripe::Subscription)
@@ -92,103 +87,23 @@ module Webhooks
       end
     end
 
-    def handle_invoice_payment_succeeded(stripe_invoice)
-      # Fetch full object if thin payload
+    def handle_invoice(stripe_invoice)
       stripe_invoice = fetch_object_if_needed(stripe_invoice, Stripe::Invoice)
 
-      customer_id = stripe_invoice.customer.is_a?(String) ? stripe_invoice.customer : stripe_invoice.customer.id
+      customer_id = Invoice.stripe_customer_id(stripe_invoice)
       account = Account.find_by(stripe_customer_id: customer_id)
       unless account
         Rails.logger.warn "[Stripe Webhook] Account not found for customer #{customer_id}"
         return
       end
 
-      subscription_id = stripe_invoice.subscription.is_a?(String) ? stripe_invoice.subscription : stripe_invoice.subscription.id
+      subscription_id = Invoice.stripe_subscription_id(stripe_invoice)
       subscription = account.subscriptions.find_by(stripe_subscription_id: subscription_id)
 
       invoice = account.invoices.find_or_initialize_by(stripe_invoice_id: stripe_invoice.id)
-      invoice.assign_attributes(
-        subscription: subscription,
-        number: stripe_invoice.number,
-        status: 'paid',
-        amount_due_cents: stripe_invoice.amount_due,
-        amount_paid_cents: stripe_invoice.amount_paid,
-        currency: stripe_invoice.currency,
-        period_start: stripe_invoice.period_start ? Time.at(stripe_invoice.period_start) : nil,
-        period_end: stripe_invoice.period_end ? Time.at(stripe_invoice.period_end) : nil,
-        paid_at: stripe_invoice.status_transitions&.paid_at ? Time.at(stripe_invoice.status_transitions.paid_at) : Time.current,
-        hosted_invoice_url: stripe_invoice.hosted_invoice_url,
-        invoice_pdf_url: stripe_invoice.invoice_pdf
-      )
-      invoice.save!
+      invoice.sync_from_stripe(stripe_invoice, subscription: subscription)
 
-      Rails.logger.info "[Stripe Webhook] Invoice #{invoice.id} marked as paid"
-    end
-
-    def handle_invoice_payment_failed(stripe_invoice)
-      # Fetch full object if thin payload
-      stripe_invoice = fetch_object_if_needed(stripe_invoice, Stripe::Invoice)
-
-      customer_id = stripe_invoice.customer.is_a?(String) ? stripe_invoice.customer : stripe_invoice.customer.id
-      account = Account.find_by(stripe_customer_id: customer_id)
-      unless account
-        Rails.logger.warn "[Stripe Webhook] Account not found for customer #{customer_id}"
-        return
-      end
-
-      subscription_id = stripe_invoice.subscription.is_a?(String) ? stripe_invoice.subscription : stripe_invoice.subscription.id
-      subscription = account.subscriptions.find_by(stripe_subscription_id: subscription_id)
-
-      invoice = account.invoices.find_or_initialize_by(stripe_invoice_id: stripe_invoice.id)
-      invoice.assign_attributes(
-        subscription: subscription,
-        number: stripe_invoice.number,
-        status: 'open',
-        amount_due_cents: stripe_invoice.amount_due,
-        amount_paid_cents: stripe_invoice.amount_paid,
-        currency: stripe_invoice.currency,
-        period_start: stripe_invoice.period_start ? Time.at(stripe_invoice.period_start) : nil,
-        period_end: stripe_invoice.period_end ? Time.at(stripe_invoice.period_end) : nil,
-        due_date: stripe_invoice.due_date ? Time.at(stripe_invoice.due_date) : nil,
-        hosted_invoice_url: stripe_invoice.hosted_invoice_url,
-        invoice_pdf_url: stripe_invoice.invoice_pdf
-      )
-      invoice.save!
-
-      Rails.logger.warn "[Stripe Webhook] Invoice #{invoice.id} payment failed"
-    end
-
-    def handle_invoice_finalized(stripe_invoice)
-      # Fetch full object if thin payload
-      stripe_invoice = fetch_object_if_needed(stripe_invoice, Stripe::Invoice)
-
-      customer_id = stripe_invoice.customer.is_a?(String) ? stripe_invoice.customer : stripe_invoice.customer.id
-      account = Account.find_by(stripe_customer_id: customer_id)
-      unless account
-        Rails.logger.warn "[Stripe Webhook] Account not found for customer #{customer_id}"
-        return
-      end
-
-      subscription_id = stripe_invoice.subscription.is_a?(String) ? stripe_invoice.subscription : stripe_invoice.subscription.id
-      subscription = account.subscriptions.find_by(stripe_subscription_id: subscription_id)
-
-      invoice = account.invoices.find_or_initialize_by(stripe_invoice_id: stripe_invoice.id)
-      invoice.assign_attributes(
-        subscription: subscription,
-        number: stripe_invoice.number,
-        status: stripe_invoice.status,
-        amount_due_cents: stripe_invoice.amount_due,
-        amount_paid_cents: stripe_invoice.amount_paid || 0,
-        currency: stripe_invoice.currency,
-        period_start: stripe_invoice.period_start ? Time.at(stripe_invoice.period_start) : nil,
-        period_end: stripe_invoice.period_end ? Time.at(stripe_invoice.period_end) : nil,
-        due_date: stripe_invoice.due_date ? Time.at(stripe_invoice.due_date) : nil,
-        hosted_invoice_url: stripe_invoice.hosted_invoice_url,
-        invoice_pdf_url: stripe_invoice.invoice_pdf
-      )
-      invoice.save!
-
-      Rails.logger.info "[Stripe Webhook] Invoice #{invoice.id} finalized"
+      Rails.logger.info "[Stripe Webhook] Synced invoice #{invoice.id} (#{invoice.status})"
     end
 
     def update_subscription_from_stripe(stripe_subscription)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -73,4 +73,46 @@ class Invoice < ApplicationRecord
   def invoice_url
     hosted_invoice_url || "#"
   end
+
+  def sync_from_stripe(stripe_invoice, subscription: nil)
+    assign_attributes(
+      self.class.stripe_attributes(stripe_invoice).merge(subscription: subscription)
+    )
+    save!
+  end
+
+  def self.stripe_attributes(stripe_invoice)
+    paid_at = stripe_invoice.status_transitions&.paid_at
+
+    {
+      number: stripe_invoice.number,
+      status: stripe_invoice.status,
+      amount_due_cents: stripe_invoice.amount_due,
+      amount_paid_cents: stripe_invoice.amount_paid || 0,
+      currency: stripe_invoice.currency,
+      period_start: stripe_time(stripe_invoice.period_start),
+      period_end: stripe_time(stripe_invoice.period_end),
+      due_date: stripe_time(stripe_invoice.due_date),
+      paid_at: stripe_time(paid_at),
+      hosted_invoice_url: stripe_invoice.hosted_invoice_url,
+      invoice_pdf_url: stripe_invoice.invoice_pdf
+    }
+  end
+
+  def self.stripe_customer_id(stripe_invoice)
+    stripe_object_id(stripe_invoice.customer)
+  end
+
+  def self.stripe_subscription_id(stripe_invoice)
+    subscription = stripe_invoice.parent&.subscription_details&.subscription
+    stripe_object_id(subscription)
+  end
+
+  def self.stripe_object_id(stripe_object)
+    stripe_object.is_a?(String) ? stripe_object : stripe_object&.id
+  end
+
+  def self.stripe_time(timestamp)
+    Time.at(timestamp) if timestamp
+  end
 end

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -65,7 +65,7 @@ class StripeService
 
     {
       subscription: subscription,
-      client_secret: stripe_subscription.latest_invoice&.confirmation_secret
+      client_secret: stripe_subscription.latest_invoice&.confirmation_secret&.client_secret
     }
   rescue Stripe::StripeError => e
     Rails.logger.error "[StripeService] Error creating subscription: #{e.message}"

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -48,7 +48,7 @@ class StripeService
       items: [{ price: plan.stripe_price_id }],
       payment_behavior: 'default_incomplete',
       payment_settings: { save_default_payment_method: 'on_subscription' },
-      expand: ['latest_invoice', 'items.data']
+      expand: ['latest_invoice.confirmation_secret', 'items.data']
     )
 
     # Create local subscription record

--- a/test/controllers/webhooks/stripe_controller_test.rb
+++ b/test/controllers/webhooks/stripe_controller_test.rb
@@ -76,7 +76,7 @@ module Webhooks
       post '/webhooks/stripe', params: payload, headers: { 'Content-Type' => 'application/json' }
     end
 
-    assert_response :ok  # Still returns 200 so Stripe doesn't retry
+    assert_response :internal_server_error
     stripe_event = StripeEvent.last
     assert_equal 'failed', stripe_event.status
     assert_not_nil stripe_event.error_message
@@ -87,9 +87,15 @@ module Webhooks
     stripe_subscription = mock('subscription')
     stripe_subscription.stubs(:id).returns('sub_123')
     stripe_subscription.stubs(:status).returns('active')
-    stripe_subscription.stubs(:current_period_start).returns(Time.current.to_i)
-    stripe_subscription.stubs(:current_period_end).returns(1.month.from_now.to_i)
     stripe_subscription.stubs(:cancel_at_period_end).returns(false)
+
+    item = mock('subscription_item')
+    item.stubs(:current_period_start).returns(Time.current.to_i)
+    item.stubs(:current_period_end).returns(1.month.from_now.to_i)
+
+    items = mock('items')
+    items.stubs(:data).returns([item])
+    stripe_subscription.stubs(:items).returns(items)
 
     event_data = mock('event_data')
     event_data.stubs(:object).returns(stripe_subscription)
@@ -174,15 +180,22 @@ module Webhooks
       stripe_invoice = mock('invoice')
       stripe_invoice.stubs(:id).returns('in_123')
       stripe_invoice.stubs(:customer).returns('cus_123')
-      stripe_invoice.stubs(:subscription).returns('sub_123')
       stripe_invoice.stubs(:number).returns('INV-001')
+      stripe_invoice.stubs(:status).returns('paid')
       stripe_invoice.stubs(:amount_due).returns(1000)
       stripe_invoice.stubs(:amount_paid).returns(1000)
       stripe_invoice.stubs(:currency).returns('usd')
       stripe_invoice.stubs(:period_start).returns(Time.current.to_i)
       stripe_invoice.stubs(:period_end).returns(1.month.from_now.to_i)
+      stripe_invoice.stubs(:due_date).returns(nil)
       stripe_invoice.stubs(:hosted_invoice_url).returns('https://invoice.stripe.com/i/123')
       stripe_invoice.stubs(:invoice_pdf).returns('https://invoice.stripe.com/i/123/pdf')
+
+      subscription_details = mock('subscription_details')
+      subscription_details.stubs(:subscription).returns('sub_123')
+      parent = mock('parent')
+      parent.stubs(:subscription_details).returns(subscription_details)
+      stripe_invoice.stubs(:parent).returns(parent)
 
       status_transitions = mock('status_transitions')
       status_transitions.stubs(:paid_at).returns(Time.current.to_i)
@@ -208,14 +221,15 @@ module Webhooks
       invoice = @account.invoices.last
       assert_equal 'paid', invoice.status
       assert_equal 1000, invoice.amount_due_cents
+      assert_equal @subscription, invoice.subscription
     end
 
     test 'handles invoice.payment_failed event' do
       stripe_invoice = mock('invoice')
       stripe_invoice.stubs(:id).returns('in_123')
       stripe_invoice.stubs(:customer).returns('cus_123')
-      stripe_invoice.stubs(:subscription).returns('sub_123')
       stripe_invoice.stubs(:number).returns('INV-001')
+      stripe_invoice.stubs(:status).returns('open')
       stripe_invoice.stubs(:amount_due).returns(1000)
       stripe_invoice.stubs(:amount_paid).returns(0)
       stripe_invoice.stubs(:currency).returns('usd')
@@ -225,6 +239,12 @@ module Webhooks
       stripe_invoice.stubs(:hosted_invoice_url).returns('https://invoice.stripe.com/i/123')
       stripe_invoice.stubs(:invoice_pdf).returns('https://invoice.stripe.com/i/123/pdf')
       stripe_invoice.stubs(:status_transitions).returns(nil)
+
+      subscription_details = mock('subscription_details')
+      subscription_details.stubs(:subscription).returns('sub_123')
+      parent = mock('parent')
+      parent.stubs(:subscription_details).returns(subscription_details)
+      stripe_invoice.stubs(:parent).returns(parent)
 
       event_data = mock('event_data')
       event_data.stubs(:object).returns(stripe_invoice)

--- a/test/factories/invoices.rb
+++ b/test/factories/invoices.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :invoice do
+    account
+    sequence(:stripe_invoice_id) { |n| "in_#{n}" }
+    sequence(:number) { |n| "INV-#{n}" }
+    status { 'draft' }
+    amount_due_cents { 0 }
+    amount_paid_cents { 0 }
+    currency { 'usd' }
+  end
+end

--- a/test/models/invoice_test.rb
+++ b/test/models/invoice_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class InvoiceTest < ActiveSupport::TestCase
+  test 'sync_from_stripe maps Clover invoice fields and subscription' do
+    account = create(:account)
+    subscription = create(:subscription, account: account, stripe_subscription_id: 'sub_123')
+    invoice = create(:invoice, account: account)
+
+    customer = mock('customer')
+    customer.stubs(:id).returns('cus_123')
+    stripe_subscription = mock('subscription')
+    stripe_subscription.stubs(:id).returns('sub_123')
+    subscription_details = mock('subscription_details')
+    subscription_details.stubs(:subscription).returns(stripe_subscription)
+    parent = mock('parent')
+    parent.stubs(:subscription_details).returns(subscription_details)
+    status_transitions = mock('status_transitions')
+    status_transitions.stubs(:paid_at).returns(1_700_000_300)
+
+    stripe_invoice = mock('stripe_invoice')
+    stripe_invoice.stubs(:customer).returns(customer)
+    stripe_invoice.stubs(:parent).returns(parent)
+    stripe_invoice.stubs(:number).returns('INV-123')
+    stripe_invoice.stubs(:status).returns('paid')
+    stripe_invoice.stubs(:amount_due).returns(1_000)
+    stripe_invoice.stubs(:amount_paid).returns(1_000)
+    stripe_invoice.stubs(:currency).returns('usd')
+    stripe_invoice.stubs(:period_start).returns(1_700_000_000)
+    stripe_invoice.stubs(:period_end).returns(1_700_000_100)
+    stripe_invoice.stubs(:due_date).returns(1_700_000_200)
+    stripe_invoice.stubs(:status_transitions).returns(status_transitions)
+    stripe_invoice.stubs(:hosted_invoice_url).returns('https://invoice.stripe.com/i/123')
+    stripe_invoice.stubs(:invoice_pdf).returns('https://invoice.stripe.com/i/123/pdf')
+
+    invoice.sync_from_stripe(stripe_invoice, subscription: subscription)
+
+    assert_equal 'cus_123', Invoice.stripe_customer_id(stripe_invoice)
+    assert_equal 'sub_123', Invoice.stripe_subscription_id(stripe_invoice)
+    assert_equal subscription, invoice.subscription
+    assert_equal 'INV-123', invoice.number
+    assert_equal 'paid', invoice.status
+    assert_equal 1_000, invoice.amount_due_cents
+    assert_equal 1_000, invoice.amount_paid_cents
+    assert_equal Time.at(1_700_000_000), invoice.period_start
+    assert_equal Time.at(1_700_000_100), invoice.period_end
+    assert_equal Time.at(1_700_000_200), invoice.due_date
+    assert_equal Time.at(1_700_000_300), invoice.paid_at
+  end
+
+  test 'stripe_subscription_id is nil for a standalone invoice' do
+    stripe_invoice = mock('stripe_invoice')
+    stripe_invoice.stubs(:parent).returns(nil)
+
+    assert_nil Invoice.stripe_subscription_id(stripe_invoice)
+  end
+end

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -88,7 +88,13 @@ class StripeServiceTest < ActiveSupport::TestCase
     @service.stubs(:create_or_retrieve_customer).returns(customer)
     Stripe::PaymentMethod.expects(:attach).with('pm_123', { customer: 'cus_123' }).returns(payment_method)
     Stripe::Customer.expects(:update).with('cus_123', invoice_settings: { default_payment_method: 'pm_123' })
-    Stripe::Subscription.expects(:create).returns(subscription)
+    Stripe::Subscription.expects(:create).with(
+      customer: 'cus_123',
+      items: [{ price: 'price_123' }],
+      payment_behavior: 'default_incomplete',
+      payment_settings: { save_default_payment_method: 'on_subscription' },
+      expand: ['latest_invoice.confirmation_secret', 'items.data']
+    ).returns(subscription)
 
     result = @service.create_subscription(plan: @plan, payment_method_id: 'pm_123')
 

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -72,8 +72,11 @@ class StripeServiceTest < ActiveSupport::TestCase
     items = mock('items')
     items.stubs(:data).returns([item])
 
+    confirmation_secret = mock('confirmation_secret')
+    confirmation_secret.stubs(:client_secret).returns('pi_secret_123')
+
     invoice = mock('invoice')
-    invoice.stubs(:confirmation_secret).returns(nil)
+    invoice.stubs(:confirmation_secret).returns(confirmation_secret)
 
     subscription = mock('subscription')
     subscription.stubs(:id).returns('sub_123')
@@ -91,6 +94,7 @@ class StripeServiceTest < ActiveSupport::TestCase
 
     assert result[:subscription].persisted?
     assert_equal 'sub_123', result[:subscription].stripe_subscription_id
+    assert_equal 'pi_secret_123', result[:client_secret]
     assert_equal 'Visa', @account.reload.payment_method_type
     assert_equal '4242', @account.payment_method_last4
   end


### PR DESCRIPTION
Fix Stripe's Clover API handling for checkout confirmation secrets and invoice webhooks. Invoice mapping now lives on `Invoice`, and failed webhook processing returns an error so Stripe can retry.